### PR TITLE
Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     ],
     "require": {
-        "php": "^8.3|^8.4",
+        "php": "^8.2",
         "filament/filament": "^3.0",
         "filament/forms": "^3.0",
         "spatie/laravel-package-tools": "^1.19.0",

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2",
+        "php": "^8.3|^8.4",
         "filament/filament": "^3.0",
         "filament/forms": "^3.0",
-        "spatie/laravel-package-tools": "^1.15.0",
-        "illuminate/contracts": "^10.0|^11.0"
+        "spatie/laravel-package-tools": "^1.19.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
This pull request includes updates to the `composer.json` file to ensure compatibility with newer versions of PHP and package dependencies.

Dependency updates:

* Updated the PHP version requirement to support versions `^8.3|^8.4`.
* Updated `spatie/laravel-package-tools` to version `^1.19.0`.
* Added support for version `^12.0` of `illuminate/contracts`.